### PR TITLE
msm8998-common: Remove configfs triggers from recovery rc

### DIFF
--- a/rootdir/etc/init.recovery.qcom.rc
+++ b/rootdir/etc/init.recovery.qcom.rc
@@ -3,22 +3,5 @@ on fs
     symlink /dev/block/platform/soc/${ro.boot.bootdevice} /dev/block/bootdevice
 
 on init
-    mount configfs none /config
-    mkdir /config/usb_gadget/g1 0770 shell shell
-    write /config/usb_gadget/g1/idVendor 0x2717
-    write /config/usb_gadget/g1/idProduct 0xff48
-    mkdir /config/usb_gadget/g1/strings/0x409 0770
-    write /config/usb_gadget/g1/strings/0x409/serialnumber ${ro.serialno}
-    write /config/usb_gadget/g1/strings/0x409/manufacturer ${ro.product.manufacturer}
-    write /config/usb_gadget/g1/strings/0x409/product ${ro.product.model}
-    mkdir /config/usb_gadget/g1/functions/ffs.adb
-    write /config/usb_gadget/g1/os_desc/use 1
     setprop sys.usb.configfs 1
-
-on property:sys.usb.ffs.ready=1
-    mkdir /config/usb_gadget/g1/configs/b.1 0777 shell shell
-    symlink /config/usb_gadget/g1/configs/b.1 /config/usb_gadget/g1/os_desc/b.1
-    mkdir /config/usb_gadget/g1/configs/b.1/strings/0x409 0770 shell shell
-    write /config/usb_gadget/g1/configs/b.1/strings/0x409/configuration "adb"
-    symlink /config/usb_gadget/g1/functions/ffs.adb /config/usb_gadget/g1/configs/b.1/f1
-    write /config/usb_gadget/g1/UDC "a800000.dwc3"
+    setprop sys.usb.controller "a800000.dwc3"


### PR DESCRIPTION
Configfs triggers will now be in the core
init.recovery.rc, similar to main system
files.

Test: Usb works in recovery
Bug: 78793464
Change-Id: I26a403425edce1d4947daf2510e28beb026ba5f6